### PR TITLE
STTV-1 - Publish config/test/source files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,2 @@
-.babelrc
-.eslintrc
 .github
 .idea
-jest.config.js
-src/index.js
-src/RetrySession.js
-tests/RetrySession.test.js
-webpack.config.js


### PR DESCRIPTION
I might have been overzealous in minimizing the published npm package size. Leaving these files in (e.g. to show linting) should increase our npm search score.